### PR TITLE
Flat Time Series Filter

### DIFF
--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -128,7 +128,7 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 			timestamp = outputTimestampList.get(index);
 			String resultArray = "";
 			for (int i = 0; i < vectorSize; i++) {
-				resultArray += value[i];
+				resultArray += value[i] + " ";
 			}
 			out.write(timestamp + ": " + resultArray + "\n");
 			index++;

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AnalysisFactory.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AnalysisFactory.java
@@ -1,5 +1,6 @@
 package org.harmony_analyser.jharmonyanalyser.services;
 
+import org.harmony_analyser.jharmonyanalyser.filters.FlatTimeSeriesFilter;
 import org.harmony_analyser.jharmonyanalyser.plugins.EmptyPlugin;
 import org.harmony_analyser.jharmonyanalyser.plugins.chordanal_plugins.*;
 import org.harmony_analyser.jharmonyanalyser.plugins.chromanal_plugins.*;
@@ -29,6 +30,7 @@ public class AnalysisFactory {
 
 	private final String[] POST_PROCESSING_FILTERS = new String[] {
 		"filters:time_series",
+		"filters:flat_time_series",
 		"filters:chord_vectors",
 		"filters:key_vectors"
 	};
@@ -100,6 +102,9 @@ public class AnalysisFactory {
 					break;
 				case "filters:time_series":
 					plugin = new TimeSeriesFilter();
+					break;
+				case "filters:flat_time_series":
+					plugin = new FlatTimeSeriesFilter();
 					break;
 				case "filters:chord_vectors":
 					plugin = new ChordVectorsFilter();

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalysisHelper.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalysisHelper.java
@@ -91,6 +91,21 @@ public class AudioAnalysisHelper {
 	// gets float from the line, after ':'
 	public static float getFloatFromLine(String line) { return Float.parseFloat(line.substring(line.lastIndexOf(':') + 2)); }
 
+	// gets float array (with given size) from the line, after ':'
+	public static float[] getFloatArrayFromLine(String line, int size) throws AudioAnalyser.IncorrectInputException {
+		float[] result = new float[size];
+		String floatValues = line.substring(line.lastIndexOf(':') + 2);
+		Scanner sc = new Scanner(floatValues);
+		for (int i = 0; i < size; i++) {
+			if (sc.hasNextFloat()) {
+				result[i] = sc.nextFloat();
+			} else {
+				throw new AudioAnalyser.IncorrectInputException("Float array information is invalid.");
+			}
+		}
+		return result;
+	}
+
 	// gets chroma information from the line of String
 	public static float[] getChromaFromLine(String line) throws AudioAnalyser.IncorrectInputException {
 		float[] result = new float[12];


### PR DESCRIPTION
The current TimeSeriesFilter https://github.com/lacimarsik/harmony-analyser/pull/7 converts `timestamp: value` pairs to a continuous series, in the way that the line graph remains the same for the converted series:
```
12.260136: 1
14.303492: 0
...
```
was converted to:
```
12.262835: 1.0
12.270136: 0.9951061
12.280136: 0.9902122
12.290136: 0.98531824
...
```
This PR adds the FlatTimeSeriesFilter, which will keep the discrete values, resulting in 'saw' jumps:
```
12.260136: 1
14.303492: 0
...
```
FlatTimeSeriesFilter will convert to:
```
12.262835: 1.0
12.270136: 1.0
12.280136: 1.0
...
14.303492: 0
14.313492: 0
```
What is good about this is, that it can work with vectors (e.g. chord vectors). So we can create a series with a fixed sample rate: `chord1, chord1, chord1, chord2, chord2, ...` where the number of repeats of the same chord represents, how long it sounds. This way we can simulate the time dimension also in DTW algorithms (since in our previous experiments we were suppressing the time dimension, taking only chord sequence).