### PR TITLE
Analysis enhancements: Outputs and suffices disambugation

### DIFF
--- a/src/main/java/org/harmony_analyser/application/VisualizationToolController.java
+++ b/src/main/java/org/harmony_analyser/application/VisualizationToolController.java
@@ -126,15 +126,15 @@ public class VisualizationToolController implements Initializable {
 		analyse3Clicked(event);
 	}
 
-	DataChart createSelectedVisualization(ChoiceBox plugin, String inputFile) throws AudioAnalyser.LoadFailedException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError, IOException, Chroma.WrongChromaSize, AudioAnalyser.OutputAlreadyExists {
+	DataChart createSelectedVisualization(ChoiceBox plugin, String inputWavFile) throws AudioAnalyser.LoadFailedException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError, IOException, Chroma.WrongChromaSize, AudioAnalyser.OutputAlreadyExists {
 		String analysisKey = plugin.getSelectionModel().getSelectedItem().toString();
 		try {
-			audioAnalyser.runAnalysis(inputFile, analysisKey, false, false);
+			audioAnalyser.runAnalysis(inputWavFile, analysisKey, false, false);
 		} catch (AudioAnalyser.OutputAlreadyExists e) {
 			System.out.println("Output already exists. Continuing.");
 		}
 
-		return audioAnalyser.createDataChart(inputFile, analysisKey);
+		return audioAnalyser.createDataChart(inputWavFile, analysisKey);
 	}
 
 	void showChart(DataChart dataChart, BarChart<String, Number> barChart, LineChart<Number, Number> lineChart, AreaChart<String, Number> areaChart) {

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/ChordVectorsFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/ChordVectorsFilter.java
@@ -47,8 +47,8 @@ public class ChordVectorsFilter extends LineChartPlugin {
 		setParameters();
 	}
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		String result = super.analyse(inputFile, force, verbose);
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
+		String result = super.analyse(inputFile, force);
 		String outputFile = inputFile + outputFileSuffix + ".txt";
 		List<String> inputFiles = new ArrayList<>();
 		for (String suffix : inputFileSuffixes) {

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/ChordVectorsFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/ChordVectorsFilter.java
@@ -41,6 +41,7 @@ public class ChordVectorsFilter extends LineChartPlugin {
 		inputFileExtension = ".txt";
 
 		outputFileSuffix = "-chord-vectors";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/ChordVectorsFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/ChordVectorsFilter.java
@@ -50,12 +50,6 @@ public class ChordVectorsFilter extends LineChartPlugin {
 
 	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		String result = super.analyse(inputFile, force);
-		String outputFile = inputFile + outputFileSuffix + ".txt";
-		List<String> inputFiles = new ArrayList<>();
-		for (String suffix : inputFileSuffixes) {
-			String inputFileName = inputFile + suffix + inputFileExtension;
-			inputFiles.add(inputFileName);
-		}
 
 		BufferedWriter out = new BufferedWriter(new FileWriter(outputFile));
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -41,9 +41,10 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 		inputFileSuffixes = new ArrayList<>();
 		inputFileSuffixes.add(""); // no suffix, arbitrary input file is allowed
-		inputFileExtension = "-flat"; // no extension, arbitrary input file is allowed
+		inputFileExtension = ".txt"; //
 
-		outputFileSuffix = ".txt"; // no suffix, will replace the input file
+		outputFileSuffix = "-flat";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("samplingRate", (float) 10);
@@ -139,7 +140,7 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 		vectorSize = Math.round(parameters.get("vectorSize"));
 	}
 
-	public VisualizationData getDataFromOutput(String outputFile) {
+	public VisualizationData getDataFromOutput(String inputWavFile) {
 		return VisualizationData.EMPTY_VISUALIZATION_DATA; // Return null object
 	}
 }

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -137,7 +137,6 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 	protected void setParameters() {
 		samplingRate = parameters.get("samplingRate");
-		vectorSize = Math.round(parameters.get("vectorSize"));
 	}
 
 	public VisualizationData getDataFromOutput(String inputWavFile) {

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -71,10 +71,10 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 		// 3. Iterate over timestamps and values, creating time series values
 		List<Float> outputTimestampList = new ArrayList<>();
 		List<ArrayList<Float>> outputValuesList = new ArrayList<>();
-		ArrayList<Float> previousValue;
+		ArrayList<Float> previousValue = new ArrayList<>();
 		float previousTimestamp, timestamp;
 		previousTimestamp = inputFileTimestampList.get(0);
-		previousValue = inputFileValuesList.get(0);
+		previousValue.addAll(inputFileValuesList.get(0));
 		float sampleLength = 1 / samplingRate;
 		int index = 0;
 		for (ArrayList<Float> floatArray : inputFileValuesList) {
@@ -98,7 +98,8 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 				while (newTimestamp < timestamp) {
 					newTimestamp += sampleLength;
 					sampleIndex++;
-					Collections.copy(previousValue, newValue);
+					newValue.clear();
+					newValue.addAll(previousValue);
 					outputTimestampList.add(newTimestamp);
 					outputValuesList.add(newValue);
 				}
@@ -120,8 +121,8 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 		for (ArrayList<Float> value : outputValuesList) {
 			timestamp = outputTimestampList.get(index);
 			String resultArray = "";
-			for (int i = 0; i < vectorSize; i++) {
-				resultArray += value.get(i) + " ";
+			for (int i = 0; i < value.size(); i++) {
+				resultArray += Float.toString(value.get(i)) + " ";
 			}
 			out.write(timestamp + ": " + resultArray + "\n");
 			index++;

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -47,7 +47,6 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 		parameters = new HashMap<>();
 		parameters.put("samplingRate", (float) 10);
-		parameters.put("vectorSize", (float) 12);
 
 		setParameters();
 	}
@@ -61,27 +60,27 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 		List<String> inputFileLinesList = Files.readAllLines(new File(inputFile).toPath(), Charset.defaultCharset());
 		List<Float> inputFileTimestampList = new ArrayList<>();
-		List<float[]> inputFileValuesList = new ArrayList<>();
+		List<ArrayList<Float>> inputFileValuesList = new ArrayList<>();
 
 		// 1. Get timestamps from the input file
 		inputFileTimestampList.addAll(inputFileLinesList.stream().map(AudioAnalysisHelper::getTimestampFromLine).collect(Collectors.toList()));
 
 		// 2. Get values from the input file
 		for (String value : inputFileLinesList) {
-			float[] floatArray = AudioAnalysisHelper.getFloatArrayFromLine(value, vectorSize);
+			ArrayList<Float> floatArray = AudioAnalysisHelper.getFloatArrayFromLine(value, vectorSize);
 			inputFileValuesList.add(floatArray);
 		}
 
 		// 3. Iterate over timestamps and values, creating time series values
 		List<Float> outputTimestampList = new ArrayList<>();
-		List<float[]> outputValuesList = new ArrayList<>();
-		float[] previousValue;
+		List<ArrayList<Float>> outputValuesList = new ArrayList<>();
+		ArrayList<Float> previousValue;
 		float previousTimestamp, timestamp;
 		previousTimestamp = inputFileTimestampList.get(0);
 		previousValue = inputFileValuesList.get(0);
 		float sampleLength = 1 / samplingRate;
 		int index = 0;
-		for (float[] floatArray : inputFileValuesList) {
+		for (ArrayList<Float> floatArray : inputFileValuesList) {
 			if (index == 0) {
 				index++;
 				continue;
@@ -94,7 +93,7 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 			if (timestampDifference > sampleLength) {
 				// CASE 1: Timestamp difference greater than sample length
 				float newTimestamp = previousTimestamp;
-				float[] newValue;
+				ArrayList<Float> newValue;
 				verboseLog("Starting with timestamp: " + newTimestamp);
 				int sampleIndex = 0;
 				float ratio = sampleLength / timestampDifference;
@@ -121,11 +120,11 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 		// 4. Rewrite input file using new timestamps and values
 		index = 0;
 		BufferedWriter out = new BufferedWriter(new FileWriter(inputFile));
-		for (float[] value : outputValuesList) {
+		for (ArrayList<Float> value : outputValuesList) {
 			timestamp = outputTimestampList.get(index);
 			String resultArray = "";
 			for (int i = 0; i < vectorSize; i++) {
-				resultArray += value[i] + " ";
+				resultArray += value.get(i) + " ";
 			}
 			out.write(timestamp + ": " + resultArray + "\n");
 			index++;

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -41,9 +41,9 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 		inputFileSuffixes = new ArrayList<>();
 		inputFileSuffixes.add(""); // no suffix, arbitrary input file is allowed
-		inputFileExtension = ""; // no extension, arbitrary input file is allowed
+		inputFileExtension = "-flat"; // no extension, arbitrary input file is allowed
 
-		outputFileSuffix = ""; // no suffix, will replace the input file
+		outputFileSuffix = ".txt"; // no suffix, will replace the input file
 
 		parameters = new HashMap<>();
 		parameters.put("samplingRate", (float) 10);

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -11,10 +11,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -58,7 +55,6 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, Chroma.WrongChromaSize, AudioAnalyser.OutputAlreadyExists {
 		String result = super.analyse(inputFile, force);
-
 		List<String> inputFileLinesList = Files.readAllLines(new File(inputFile).toPath(), Charset.defaultCharset());
 		List<Float> inputFileTimestampList = new ArrayList<>();
 		List<ArrayList<Float>> inputFileValuesList = new ArrayList<>();
@@ -68,7 +64,7 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 		// 2. Get values from the input file
 		for (String value : inputFileLinesList) {
-			ArrayList<Float> floatArray = AudioAnalysisHelper.getFloatArrayFromLine(value, vectorSize);
+			ArrayList<Float> floatArray = AudioAnalysisHelper.getFloatArrayFromLine(value);
 			inputFileValuesList.add(floatArray);
 		}
 
@@ -94,7 +90,7 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 			if (timestampDifference > sampleLength) {
 				// CASE 1: Timestamp difference greater than sample length
 				float newTimestamp = previousTimestamp;
-				ArrayList<Float> newValue;
+				ArrayList<Float> newValue = new ArrayList<>();
 				verboseLog("Starting with timestamp: " + newTimestamp);
 				int sampleIndex = 0;
 				float ratio = sampleLength / timestampDifference;
@@ -102,7 +98,7 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 				while (newTimestamp < timestamp) {
 					newTimestamp += sampleLength;
 					sampleIndex++;
-					newValue = previousValue;
+					Collections.copy(previousValue, newValue);
 					outputTimestampList.add(newTimestamp);
 					outputValuesList.add(newValue);
 				}

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -120,7 +120,7 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 		// 4. Rewrite input file using new timestamps and values
 		index = 0;
-		BufferedWriter out = new BufferedWriter(new FileWriter(inputFile));
+		BufferedWriter out = new BufferedWriter(new FileWriter(outputFile));
 		for (ArrayList<Float> value : outputValuesList) {
 			timestamp = outputTimestampList.get(index);
 			String resultArray = "";

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -46,7 +46,7 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 		outputFileSuffix = ""; // no suffix, will replace the input file
 
 		parameters = new HashMap<>();
-		parameters.put("samplingRate", (float) 100);
+		parameters.put("samplingRate", (float) 10);
 		parameters.put("vectorSize", (float) 12);
 
 		setParameters();

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -56,8 +56,8 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 	 * Filters the result text file, creating a fixed sampling rate time series
 	 */
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, Chroma.WrongChromaSize, AudioAnalyser.OutputAlreadyExists {
-		String result = super.analyse(inputFile, force, verbose);
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, Chroma.WrongChromaSize, AudioAnalyser.OutputAlreadyExists {
+		String result = super.analyse(inputFile, force);
 
 		List<String> inputFileLinesList = Files.readAllLines(new File(inputFile).toPath(), Charset.defaultCharset());
 		List<Float> inputFileTimestampList = new ArrayList<>();

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/FlatTimeSeriesFilter.java
@@ -59,9 +59,6 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, Chroma.WrongChromaSize, AudioAnalyser.OutputAlreadyExists {
 		String result = super.analyse(inputFile, force, verbose);
 
-		String outputFileVerbose = inputFile + outputFileSuffix + "-verbose" + ".txt";
-		BufferedWriter outVerbose = new BufferedWriter(new FileWriter(outputFileVerbose));
-
 		List<String> inputFileLinesList = Files.readAllLines(new File(inputFile).toPath(), Charset.defaultCharset());
 		List<Float> inputFileTimestampList = new ArrayList<>();
 		List<float[]> inputFileValuesList = new ArrayList<>();
@@ -93,12 +90,12 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 
 			// Find out difference between timestamps
 			float timestampDifference = timestamp - previousTimestamp;
-			outVerbose.write("timestampDifference: " + timestampDifference + "\n");
+			verboseLog("timestampDifference: " + timestampDifference);
 			if (timestampDifference > sampleLength) {
 				// CASE 1: Timestamp difference greater than sample length
 				float newTimestamp = previousTimestamp;
 				float[] newValue;
-				outVerbose.write("STARTING WITH timestamp: " + newTimestamp + "\n");
+				verboseLog("Starting with timestamp: " + newTimestamp);
 				int sampleIndex = 0;
 				float ratio = sampleLength / timestampDifference;
 				// iteratively create samples from the slope defined by successive points
@@ -134,7 +131,6 @@ public class FlatTimeSeriesFilter extends AnalysisFilter {
 			index++;
 		}
 		out.close();
-		outVerbose.close();
 
 		return result;
 	}

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/KeyVectorsFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/KeyVectorsFilter.java
@@ -40,6 +40,7 @@ public class KeyVectorsFilter extends LineChartPlugin {
 		inputFileExtension = ".txt";
 
 		outputFileSuffix = "-key-vectors";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/KeyVectorsFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/KeyVectorsFilter.java
@@ -46,8 +46,8 @@ public class KeyVectorsFilter extends LineChartPlugin {
 		setParameters();
 	}
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		String result = super.analyse(inputFile, force, verbose);
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
+		String result = super.analyse(inputFile, force);
 		String outputFile = inputFile + outputFileSuffix + ".txt";
 		List<String> inputFiles = new ArrayList<>();
 		for (String suffix : inputFileSuffixes) {

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/KeyVectorsFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/KeyVectorsFilter.java
@@ -49,12 +49,6 @@ public class KeyVectorsFilter extends LineChartPlugin {
 
 	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		String result = super.analyse(inputFile, force);
-		String outputFile = inputFile + outputFileSuffix + ".txt";
-		List<String> inputFiles = new ArrayList<>();
-		for (String suffix : inputFileSuffixes) {
-			String inputFileName = inputFile + suffix + inputFileExtension;
-			inputFiles.add(inputFileName);
-		}
 
 		BufferedWriter out = new BufferedWriter(new FileWriter(outputFile));
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/TimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/TimeSeriesFilter.java
@@ -38,9 +38,10 @@ public class TimeSeriesFilter extends AnalysisFilter {
 
 		inputFileSuffixes = new ArrayList<>();
 		inputFileSuffixes.add(""); // no suffix, arbitrary input file is allowed
-		inputFileExtension = ""; // no extension, arbitrary input file is allowed
+		inputFileExtension = ".txt";
 
-		outputFileSuffix = ""; // no suffix, will replace the input file
+		outputFileSuffix = "-series";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("samplingRate", (float) 100);
@@ -129,7 +130,7 @@ public class TimeSeriesFilter extends AnalysisFilter {
 		samplingRate = parameters.get("samplingRate");
 	}
 
-	public VisualizationData getDataFromOutput(String outputFile) {
+	public VisualizationData getDataFromOutput(String inputWavFile) {
 		return VisualizationData.EMPTY_VISUALIZATION_DATA; // Return null object
 	}
 }

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/TimeSeriesFilter.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/filters/TimeSeriesFilter.java
@@ -52,11 +52,8 @@ public class TimeSeriesFilter extends AnalysisFilter {
 	 * Filters the result text file, creating a fixed sampling rate time series
 	 */
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, Chroma.WrongChromaSize, AudioAnalyser.OutputAlreadyExists {
-		String result = super.analyse(inputFile, force, verbose);
-
-		String outputFileVerbose = inputFile + outputFileSuffix + "-verbose" + ".txt";
-		BufferedWriter outVerbose = new BufferedWriter(new FileWriter(outputFileVerbose));
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, Chroma.WrongChromaSize, AudioAnalyser.OutputAlreadyExists {
+		String result = super.analyse(inputFile, force);
 
 		List<String> inputFileLinesList = Files.readAllLines(new File(inputFile).toPath(), Charset.defaultCharset());
 		List<Float> inputFileTimestampList = new ArrayList<>();
@@ -86,13 +83,13 @@ public class TimeSeriesFilter extends AnalysisFilter {
 			// Find out difference between timestamps and values
 			float timestampDifference = timestamp - previousTimestamp;
 			float valueDifference = value - previousValue;
-			outVerbose.write("timestampDifference: " + timestampDifference + "\n");
-			outVerbose.write("valueDifference: " + valueDifference + "\n");
+			verboseLog("timestampDifference: " + timestampDifference);
+			verboseLog("valueDifference: " + valueDifference);
 			if (timestampDifference > sampleLength) {
 				// CASE 1: Timestamp difference greater than sample length
 				float newTimestamp = previousTimestamp;
 				float newValue;
-				outVerbose.write("STARTING WITH timestamp: " + newTimestamp + "\n");
+				verboseLog("Starting with timestamp: " + newTimestamp);
 				int sampleIndex = 0;
 				float ratio = sampleLength / timestampDifference;
 				// iteratively create samples from the slope defined by successive points
@@ -124,7 +121,6 @@ public class TimeSeriesFilter extends AnalysisFilter {
 			index++;
 		}
 		out.close();
-		outVerbose.close();
 
 		return result;
 	}

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/EmptyPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/EmptyPlugin.java
@@ -6,11 +6,11 @@ public class EmptyPlugin extends AnalysisPlugin {
 	protected void setParameters() { /* Do nothing */ }
 
 	@Override
-	public String analyse(String inputFile, boolean force, boolean verbose) {
+	public String analyse(String inputFile, boolean force) {
 		return "";
 	}
 
-	public VisualizationData getDataFromOutput(String outputFile) {
+	public VisualizationData getDataFromOutput(String inputWavFile) {
 		return VisualizationData.EMPTY_VISUALIZATION_DATA; // Return null object
 	}
 }

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/LineChartPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/LineChartPlugin.java
@@ -14,11 +14,11 @@ import java.util.List;
 @SuppressWarnings("SameParameterValue")
 
 public abstract class LineChartPlugin extends AnalysisPlugin {
-	public VisualizationData getDataFromOutput(String outputFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError {
+	public VisualizationData getDataFromOutput(String inputWavFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists {
 		VisualizationData data = super.prepareVisualizationData();
 		List<Float> timestamps = new ArrayList<>();
 		List<Float> values = new ArrayList<>();
-		List<String> linesList = readOutputFile(outputFile);
+		List<String> linesList = readOutputFile(inputWavFile);
 
 		float timestamp, value;
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/AverageChordComplexityDistancePlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/AverageChordComplexityDistancePlugin.java
@@ -45,6 +45,7 @@ public class AverageChordComplexityDistancePlugin extends ChordAnalyserPlugin {
 		inputFileExtension = ".txt";
 
 		outputFileSuffix = "-average-cc-distance";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("audibleThreshold", (float) 0.07);
@@ -55,11 +56,11 @@ public class AverageChordComplexityDistancePlugin extends ChordAnalyserPlugin {
 	}
 
 	@Override
-	public VisualizationData getDataFromOutput(String outputFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError {
+	public VisualizationData getDataFromOutput(String inputWavFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists {
 		VisualizationData data = super.prepareVisualizationData();
 		List<Float> values = new ArrayList<>();
 		List<String> labels = new ArrayList<>();
-		List<String> linesList = readOutputFile(outputFile);
+		List<String> linesList = readOutputFile(inputWavFile);
 
 		/* Plugin-specific parsing of the result */
 		// get last NUMBER_OUTPUTS lines

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordAnalyserPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordAnalyserPlugin.java
@@ -119,7 +119,6 @@ abstract class ChordAnalyserPlugin extends LineChartPlugin {
 		int sumOfAllTones = 0;
 		float timestamp;
 		BufferedWriter out = new BufferedWriter(new FileWriter(outputFile));
-		//BufferedWriter outVerbose = new BufferedWriter(new FileWriter(outputFileVerbose));
 
 		// 3. Iterate over chord progression, deriving chord and transition complexities
 		for (int[] chord : chordProgression) {
@@ -129,9 +128,7 @@ abstract class ChordAnalyserPlugin extends LineChartPlugin {
 
 			// get timestamp of this transition
 			timestamp = timestampList.get(chordProgression.indexOf(chord));
-			if (verbose) {
-				//outVerbose.write(timestamp + ":\n");
-			}
+			verboseLog("timestamp: " + timestamp);
 
 			// create chords using Chordanal
 			String currentChordTones = Chordanal.getStringOfTones(chord);
@@ -140,25 +137,19 @@ abstract class ChordAnalyserPlugin extends LineChartPlugin {
 			Chord chord2 = Chordanal.createHarmonyFromRelativeTones(currentChordTones);
 
 			if (chord1.equals(Chord.EMPTY_CHORD) || chord2.equals(Chord.EMPTY_CHORD)) {
-				if (verbose) {
-					//outVerbose.write("SKIP (one or both chords were not assigned)\n\n");
-				}
+				verboseLog("SKIP (one or both chords were not assigned)");
 			} else {
 				// Print chord names to output
 				String harmonyName1 = Chordanal.getHarmonyName(chord1);
 				String harmonyName2 = Chordanal.getHarmonyName(chord2);
 
-				if (verbose) {
-					//outVerbose.write(previousChordTones + "-> " + currentChordTones + "\n");
-					//outVerbose.write(harmonyName1 + "-> " + harmonyName2 + "\n");
-				}
+				verboseLog(previousChordTones + "-> " + currentChordTones);
+				verboseLog(harmonyName1 + "-> " + harmonyName2);
 
 				// Get transition complexity using Harmanal
 				int transitionComplexity = Harmanal.getTransitionComplexity(chord1, chord2);
 				if (transitionComplexity == -1) {
-					if (verbose) {
-						//outVerbose.write("transition: NO COMMON ROOTS (maximal complexity: " + maximalComplexity + ")\n");
-					}
+					verboseLog("transition: NO COMMON ROOTS (maximal complexity: " + maximalComplexity + ")");
 					transitionComplexity = maximalComplexity;
 				} else {
 					List<String> transitionsFormatted = Harmanal.getTransitionsFormatted(chord1, chord2);
@@ -168,9 +159,7 @@ abstract class ChordAnalyserPlugin extends LineChartPlugin {
 					} else {
 						transitionFormatted = transitionsFormatted.get(0);
 					}
-					if (verbose) {
-						//outVerbose.write("transition: " + transitionFormatted + "\n");
-					}
+					verboseLog("transition: " + transitionFormatted);
 				}
 				transitionComplexityList.add(transitionComplexity);
 
@@ -189,9 +178,7 @@ abstract class ChordAnalyserPlugin extends LineChartPlugin {
 				if (chordComplexity > maximalChordComplexity) {
 					maximalChordComplexity = chordComplexity;
 				}
-				if (verbose) {
-					//outVerbose.write("transition complexity: " + transitionComplexity + "\n\n");
-				}
+				verboseLog("transition complexity: " + transitionComplexity);
 				out.write(this.getTransitionOutput(timestamp, transitionComplexity));
 			}
 
@@ -206,9 +193,7 @@ abstract class ChordAnalyserPlugin extends LineChartPlugin {
 		String analysisResult = this.getFinalResult(hc, acc, rtd);
 		result += analysisResult;
 		out.write(analysisResult);
-
 		out.close();
-		//outVerbose.close();
 
 		return result;
 	}

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordAnalyserPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordAnalyserPlugin.java
@@ -36,12 +36,6 @@ abstract class ChordAnalyserPlugin extends LineChartPlugin {
 
 	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		String result = super.analyse(inputFile, force);
-		String outputFile = inputFile + outputFileSuffix + ".txt";
-		List<String> inputFiles = new ArrayList<>();
-		for (String suffix : inputFileSuffixes) {
-			String inputFileName = inputFile + suffix + inputFileExtension;
-			inputFiles.add(inputFileName);
-		}
 
 		List<String> chromaLinesList = Files.readAllLines(new File(inputFiles.get(0)).toPath(), Charset.defaultCharset());
 		List<String> segmentationLinesList = Files.readAllLines(new File(inputFiles.get(1)).toPath(), Charset.defaultCharset());

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordAnalyserPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordAnalyserPlugin.java
@@ -34,10 +34,9 @@ abstract class ChordAnalyserPlugin extends LineChartPlugin {
 	 *    - segmentation file: name of the file containing segmentation information (suffix: -chordino-labels.txt, historically, since we have used Chordino segments)
 	 */
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		String result = super.analyse(inputFile, force, verbose);
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
+		String result = super.analyse(inputFile, force);
 		String outputFile = inputFile + outputFileSuffix + ".txt";
-		String outputFileVerbose = inputFile + outputFileSuffix + "-verbose" + ".txt";
 		List<String> inputFiles = new ArrayList<>();
 		for (String suffix : inputFileSuffixes) {
 			String inputFileName = inputFile + suffix + inputFileExtension;

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordComplexityDistancePlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordComplexityDistancePlugin.java
@@ -38,6 +38,7 @@ public class ChordComplexityDistancePlugin extends ChordAnalyserPlugin {
 		inputFileExtension = ".txt";
 
 		outputFileSuffix = "-cc-distance";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("audibleThreshold", (float) 0.07);

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/TPSDistancePlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/TPSDistancePlugin.java
@@ -55,12 +55,6 @@ public class TPSDistancePlugin extends LineChartPlugin {
 
 	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		String result = super.analyse(inputFile, force);
-		String outputFile = inputFile + outputFileSuffix + ".txt";
-		List<String> inputFiles = new ArrayList<>();
-		for (String suffix : inputFileSuffixes) {
-			String inputFileName = inputFile + suffix + inputFileExtension;
-			inputFiles.add(inputFileName);
-		}
 
 		BufferedWriter out = new BufferedWriter(new FileWriter(outputFile));
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/TPSDistancePlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/TPSDistancePlugin.java
@@ -46,6 +46,7 @@ public class TPSDistancePlugin extends LineChartPlugin {
 		inputFileExtension = ".txt";
 
 		outputFileSuffix = "-tps-distance";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/TPSDistancePlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/TPSDistancePlugin.java
@@ -52,10 +52,9 @@ public class TPSDistancePlugin extends LineChartPlugin {
 		setParameters();
 	}
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		String result = super.analyse(inputFile, force, verbose);
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
+		String result = super.analyse(inputFile, force);
 		String outputFile = inputFile + outputFileSuffix + ".txt";
-		String outputFileVerbose = inputFile + outputFileSuffix + "-verbose" + ".txt";
 		List<String> inputFiles = new ArrayList<>();
 		for (String suffix : inputFileSuffixes) {
 			String inputFileName = inputFile + suffix + inputFileExtension;
@@ -63,9 +62,8 @@ public class TPSDistancePlugin extends LineChartPlugin {
 		}
 
 		BufferedWriter out = new BufferedWriter(new FileWriter(outputFile));
-		BufferedWriter outVerbose = new BufferedWriter(new FileWriter(outputFileVerbose));
 
-		if (verbose) outVerbose.write("Preparing chords from Chordino analysis ...\n");
+		verboseLog("Preparing chords from Chordino analysis ...");
 
 		// 0. Pre-process Chordino chord tones output so it contains only 1 timestamp and relative chord tone names
 		// prepares:
@@ -96,9 +94,8 @@ public class TPSDistancePlugin extends LineChartPlugin {
 			lineIndex++;
 		}
 
-		if (verbose) outVerbose.write(chordList.size() + " chords prepared\n\n");
-
-		if (verbose) outVerbose.write("Reading Chord labels and keys  ...\n");
+		verboseLog(chordList.size() + " chords prepared");
+		verboseLog("Reading Chord labels and keys  ...");
 
 		// 1. Get timestamps from the chord labels and keys file
 		// prepares:
@@ -117,7 +114,7 @@ public class TPSDistancePlugin extends LineChartPlugin {
 		keyList.addAll(keyLinesList.stream().map(AudioAnalysisHelper::getLabelFromLine).collect(Collectors.toList()));
 		keyTimestampList.addAll(keyLinesList.stream().map(AudioAnalysisHelper::getTimestampFromLine).collect(Collectors.toList()));
 
-		if (verbose) outVerbose.write(chordLabelList.size() + " chord labels and " + keyList.size() + " keys successfully read\n\n");
+		verboseLog(chordLabelList.size() + " chord labels and " + keyList.size() + " keys successfully read");
 
 		int chordIndex = 0, chordLabelIndex = 0;
 		float chordLabelTimestamp;
@@ -143,13 +140,13 @@ public class TPSDistancePlugin extends LineChartPlugin {
 			chordLabelTimestamp = chordLabelTimestampList.get(chordLabelIndex);
 			chordTimestamp = chordTimestampList.get(chordIndex);
 			if (chordLabelTimestamp != chordTimestamp) {
-				if (verbose) outVerbose.write("SKIP: Timestamp of chord and chord label did not match " + chordLabelTimestamp + " and " +  chordTimestamp + "\n");
+				verboseLog("SKIP: Timestamp of chord and chord label did not match " + chordLabelTimestamp + " and " +  chordTimestamp);
 				chordIndex--; // do not move chordIndex this iteration
 			} else {
 				// if next key timestamp is lower than currently examined chord timestamp
 				if (((keyIndex + 1) < keyTimestampList.size()) && (keyTimestampList.get(keyIndex + 1) <= chordLabelTimestamp)) {
 					// => go to the next key timestamp
-					if (verbose) outVerbose.write("KEY CHANGE: Moving to next key label\n");
+					verboseLog("KEY CHANGE: Moving to next key label");
 					keyIndex++;
 				}
 
@@ -160,11 +157,11 @@ public class TPSDistancePlugin extends LineChartPlugin {
 				key = Chordanal.createKeyFromName(keyList.get(keyIndex));
 
 				if ((chordRoot == Tone.EMPTY_TONE) || (previousChordRoot == Tone.EMPTY_TONE) || (chord == Chord.EMPTY_CHORD) || (previousChord == Chord.EMPTY_CHORD) || (key == Key.EMPTY_KEY) || (previousKey == Key.EMPTY_KEY)) {
-					if (verbose) outVerbose.write("SKIP (one or both chords were not assigned)\n\n");
+					verboseLog("SKIP (one or both chords were not assigned)");
 				} else {
 					// Get TPS Distance of the two chords
 					float tpsDistance = TonalPitchSpace.getTPSDistance(chord, chordRoot, key, previousChord, previousChordRoot, previousKey, verbose);
-					if (verbose) outVerbose.write("chord: " + chordLabel + ", previousChord: " + previousChordLabel + ", distance: " + tpsDistance + "\n\n");
+					verboseLog("chord: " + chordLabel + ", previousChord: " + previousChordLabel + ", distance: " + tpsDistance);
 					out.write(chordLabelTimestamp + ": " + tpsDistance + "\n");
 				}
 				previousChord = chord;
@@ -177,7 +174,6 @@ public class TPSDistancePlugin extends LineChartPlugin {
 		}
 
 		out.close();
-		outVerbose.close();
 
 		return result;
 	}

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chromanal_plugins/ChromaAnalyserPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chromanal_plugins/ChromaAnalyserPlugin.java
@@ -32,12 +32,6 @@ abstract class ChromaAnalyserPlugin extends LineChartPlugin {
 
 	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		String result = super.analyse(inputFile, force);
-		String outputFile = inputFile + outputFileSuffix + ".txt";
-		List<String> inputFiles = new ArrayList<>();
-		for (String suffix : inputFileSuffixes) {
-			String inputFileName = inputFile + suffix + inputFileExtension;
-			inputFiles.add(inputFileName);
-		}
 
 		List<String> chromaLinesList = Files.readAllLines(new File(inputFiles.get(0)).toPath(), Charset.defaultCharset());
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chromanal_plugins/ChromaAnalyserPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chromanal_plugins/ChromaAnalyserPlugin.java
@@ -30,8 +30,8 @@ abstract class ChromaAnalyserPlugin extends LineChartPlugin {
 	 *    - chromaFile: name of the file containing chroma information (suffix: -chromas.txt)
 	 */
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		String result = super.analyse(inputFile, force, verbose);
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
+		String result = super.analyse(inputFile, force);
 		String outputFile = inputFile + outputFileSuffix + ".txt";
 		List<String> inputFiles = new ArrayList<>();
 		for (String suffix : inputFileSuffixes) {

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chromanal_plugins/ComplexityDifferencePlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chromanal_plugins/ComplexityDifferencePlugin.java
@@ -27,6 +27,7 @@ public class ComplexityDifferencePlugin extends ChromaAnalyserPlugin {
 		inputFileExtension = ".txt";
 
 		outputFileSuffix = "-chroma-complexity-difference";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("audibleThreshold", (float) 0.07);

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chromanal_plugins/SimpleDifferencePlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/chromanal_plugins/SimpleDifferencePlugin.java
@@ -27,6 +27,7 @@ public class SimpleDifferencePlugin extends ChromaAnalyserPlugin {
 		inputFileExtension = ".txt";
 
 		outputFileSuffix = "-chroma-simple-difference";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoLabelsPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoLabelsPlugin.java
@@ -60,6 +60,7 @@ public class ChordinoLabelsPlugin extends SegmentationVampPlugin {
 		inputFileExtension = ""; // Plugin handles raw WAV files
 
 		outputFileSuffix = "-chordino-labels";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("useNNLS", (float) 1.0);

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoLabelsPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoLabelsPlugin.java
@@ -57,7 +57,7 @@ public class ChordinoLabelsPlugin extends SegmentationVampPlugin {
 
 		inputFileSuffixes = new ArrayList<>();
 		inputFileSuffixes.add(""); // Plugin handles raw WAV files
-		inputFileExtension = ""; // Plugin handles raw WAV files
+		inputFileExtension = ".wav";
 
 		outputFileSuffix = "-chordino-labels";
 		outputFileExtension = ".txt";

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoTonesPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoTonesPlugin.java
@@ -58,7 +58,7 @@ public class ChordinoTonesPlugin extends SegmentationVampPlugin {
 
 		inputFileSuffixes = new ArrayList<>();
 		inputFileSuffixes.add(""); // Plugin handles raw WAV files
-		inputFileExtension = ""; // Plugin handles raw WAV files
+		inputFileExtension = ".wav";
 
 		outputFileSuffix = "-chordino-tones";
 		outputFileExtension = ".txt";

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoTonesPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoTonesPlugin.java
@@ -61,6 +61,7 @@ public class ChordinoTonesPlugin extends SegmentationVampPlugin {
 		inputFileExtension = ""; // Plugin handles raw WAV files
 
 		outputFileSuffix = "-chordino-tones";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("useNNLS", (float) 1.0);

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/KeyDetectorPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/KeyDetectorPlugin.java
@@ -49,6 +49,7 @@ public class KeyDetectorPlugin extends SegmentationVampPlugin {
 		inputFileExtension = ""; // Plugin handles raw WAV files
 
 		outputFileSuffix = "-key";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("tuning", (float) 440.0);

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/KeyDetectorPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/KeyDetectorPlugin.java
@@ -46,7 +46,7 @@ public class KeyDetectorPlugin extends SegmentationVampPlugin {
 
 		inputFileSuffixes = new ArrayList<>();
 		inputFileSuffixes.add(""); // Plugin handles raw WAV files
-		inputFileExtension = ""; // Plugin handles raw WAV files
+		inputFileExtension = ".wav";
 
 		outputFileSuffix = "-key";
 		outputFileExtension = ".txt";

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/NNLSPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/NNLSPlugin.java
@@ -57,7 +57,7 @@ public class NNLSPlugin extends VampPlugin {
 
 		inputFileSuffixes = new ArrayList<>();
 		inputFileSuffixes.add(""); // Plugin handles raw WAV files
-		inputFileExtension = ""; // Plugin handles raw WAV files
+		inputFileExtension = ".wav";
 
 		outputFileSuffix = "-chromas";
 		outputFileExtension = ".txt";

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/NNLSPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/NNLSPlugin.java
@@ -60,6 +60,7 @@ public class NNLSPlugin extends VampPlugin {
 		inputFileExtension = ""; // Plugin handles raw WAV files
 
 		outputFileSuffix = "-chromas";
+		outputFileExtension = ".txt";
 
 		parameters = new HashMap<>();
 		parameters.put("useNNLS", (float) 1);
@@ -73,7 +74,7 @@ public class NNLSPlugin extends VampPlugin {
 		setParameters();
 	}
 
-	public VisualizationData getDataFromOutput(String outputFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError {
+	public VisualizationData getDataFromOutput(String inputWavFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError {
 		return VisualizationData.EMPTY_VISUALIZATION_DATA;
 	}
 }

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/SegmentationVampPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/SegmentationVampPlugin.java
@@ -12,11 +12,11 @@ import java.util.List;
  */
 
 abstract class SegmentationVampPlugin extends VampPlugin {
-	public VisualizationData getDataFromOutput(String outputFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError {
+	public VisualizationData getDataFromOutput(String inputWavFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists {
 		VisualizationData data = super.prepareVisualizationData();
 		List<Float> timestamps = new ArrayList<>();
 		List<String> labels = new ArrayList<>();
-		List<String> linesList = readOutputFile(outputFile);
+		List<String> linesList = readOutputFile(inputWavFile);
 
 		/* Plugin-specific parsing of the result */
 		float timestamp;

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/VampPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/VampPlugin.java
@@ -150,8 +150,8 @@ abstract class VampPlugin extends AnalysisPlugin {
 	 * @param inputFile [String] name of the WAV audio file
 	 */
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		String result = super.analyse(inputFile, force, verbose);
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
+		String result = super.analyse(inputFile, force);
 		String outputFile = inputFile + outputFileSuffix + ".txt";
 		List<String> inputFiles = new ArrayList<>();
 		for (String suffix : inputFileSuffixes) {

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/VampPlugin.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/VampPlugin.java
@@ -152,13 +152,6 @@ abstract class VampPlugin extends AnalysisPlugin {
 
 	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		String result = super.analyse(inputFile, force);
-		String outputFile = inputFile + outputFileSuffix + ".txt";
-		List<String> inputFiles = new ArrayList<>();
-		for (String suffix : inputFileSuffixes) {
-			String inputFileName = inputFile + suffix + inputFileExtension;
-			inputFiles.add(inputFileName);
-		}
-
 		try {
 			File f = new File(inputFiles.get(0));
 			AudioInputStream stream = AudioSystem.getAudioInputStream(f);

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/Analysis.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/Analysis.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -20,7 +21,7 @@ public abstract class Analysis {
 	public boolean verbose = false; // Verbose output on/off
 	public String inputWavFile = ""; // inputWavFile is set with the analysis and remembered after. It is the name of the song.
 	public String inputTitle = ""; // inputTitle is set with the analysis and remembered after. It is the name of the song without extension.
-	public List<String> inputFiles = null; // inputFiles are set with the analysis and remembered after. They are the dependency files needed around the WAV file.
+	public List<String> inputFiles = new ArrayList<>(); // inputFiles are set with the analysis and remembered after. They are the dependency files needed around the WAV file.
 	public String outputFile = ""; // outputFile is set with the analysis and remembered after.
 
 	protected static List<String> inputFileSuffixes;

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/Analysis.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/Analysis.java
@@ -17,6 +17,8 @@ import java.util.Map;
 @SuppressWarnings("SameParameterValue")
 
 public abstract class Analysis {
+	public boolean verbose = false; // Verbose output on/off
+
 	protected static List<String> inputFileSuffixes;
 	protected String inputFileExtension;
 	protected static String outputFileSuffix;
@@ -76,7 +78,7 @@ public abstract class Analysis {
 
 	protected abstract void setParameters();
 
-	public String analyse(String inputFile, boolean force, boolean verbose) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
+	public String analyse(String inputFile, boolean force) throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		String result = "";
 		checkInputFiles(inputFile, force);
 		result += "\nBeginning analysis: " + key + "\n";
@@ -87,10 +89,14 @@ public abstract class Analysis {
 			result += inputFileName + "\n";
 		}
 		result += "\nOutput file:\n" + inputFile + outputFileSuffix + ".txt" + "\n";
-		if (verbose) {
-			result += "Verbose Output:\n" + inputFile + outputFileSuffix + "-verbose" + ".txt" + "\n";
-		}
+
 		return result;
+	}
+
+	public void verboseLog(String message) {
+		if (verbose) {
+			System.out.println("(Verbose) " + message);
+		}
 	}
 
 	public abstract VisualizationData getDataFromOutput(String outputFile) throws IOException, AudioAnalyser.OutputNotReady, AudioAnalyser.ParseOutputError;

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/Analysis.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/Analysis.java
@@ -42,7 +42,10 @@ public abstract class Analysis {
 		checkInputFiles(inputTitle);
 	}
 
-	public void setTitle(String inputWavFile) {
+	public void setTitle(String inputWavFile) throws AudioAnalyser.IncorrectInputException {
+		if (inputWavFile.lastIndexOf('.') == -1) {
+			throw new AudioAnalyser.IncorrectInputException("Input file name does not have an extension");
+		}
 		inputTitle = inputWavFile.substring(0, inputWavFile.lastIndexOf('.'));
 	}
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AnalysisFactory.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AnalysisFactory.java
@@ -66,7 +66,7 @@ public class AnalysisFactory {
 		return WRAPPED_VAMP_PLUGINS;
 	}
 
-	public Analysis createPlugin(String analysisKey) throws AudioAnalyser.LoadFailedException {
+	public Analysis createAnalysis(String analysisKey) throws AudioAnalyser.LoadFailedException {
 		Analysis plugin;
 		try {
 			switch (analysisKey) {
@@ -118,6 +118,13 @@ public class AnalysisFactory {
 		} catch (PluginLoader.LoadFailedException e) {
 			throw new AudioAnalyser.LoadFailedException(e.getMessage());
 		}
+		return plugin;
+	}
+
+	public Analysis createAnalysis(String analysisKey, boolean verbose) {
+		Analysis plugin = createAnalysis(analysisKey);
+		plugin.verbose = verbose;
+
 		return plugin;
 	}
 }

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AnalysisFactory.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AnalysisFactory.java
@@ -121,7 +121,7 @@ public class AnalysisFactory {
 		return plugin;
 	}
 
-	public Analysis createAnalysis(String analysisKey, boolean verbose) {
+	public Analysis createAnalysis(String analysisKey, boolean verbose) throws AudioAnalyser.LoadFailedException {
 		Analysis plugin = createAnalysis(analysisKey);
 		plugin.verbose = verbose;
 

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalyser.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalyser.java
@@ -137,8 +137,8 @@ public class AudioAnalyser {
 		return outputWriteBuffer;
 	}
 
-	public DataChart createDataChart(String inputFile, String analysisKey) throws LoadFailedException, OutputNotReady, ParseOutputError, IOException {
-		return dataChartFactory.createDataChart(analysisKey, analysisFactory.createAnalysis(analysisKey).getDataFromOutput(inputFile));
+	public DataChart createDataChart(String inputWavFile, String analysisKey) throws LoadFailedException, OutputNotReady, ParseOutputError, IOException, IncorrectInputException, OutputAlreadyExists {
+		return dataChartFactory.createDataChart(analysisKey, analysisFactory.createAnalysis(analysisKey).getDataFromOutput(inputWavFile));
 	}
 
 	// Analyses folder with given Analysis, writes to System.out as well as writes to outputWriteBuffer

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalyser.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalyser.java
@@ -119,26 +119,26 @@ public class AudioAnalyser {
 	}
 
 	public String getPluginName(String analysisKey) throws LoadFailedException {
-		return analysisFactory.createPlugin(analysisKey).name;
+		return analysisFactory.createAnalysis(analysisKey).name;
 	}
 
 	public String getPluginDescription(String analysisKey) throws LoadFailedException {
-		return analysisFactory.createPlugin(analysisKey).description;
+		return analysisFactory.createAnalysis(analysisKey).description;
 	}
 
 	public String printParameters(String analysisKey) throws LoadFailedException {
-		return analysisFactory.createPlugin(analysisKey).printParameters();
+		return analysisFactory.createAnalysis(analysisKey).printParameters();
 	}
 
 	public String runAnalysis(String inputFile, String analysisKey, boolean force, boolean verbose) throws AudioAnalyser.IncorrectInputException, OutputAlreadyExists, IOException, LoadFailedException, Chroma.WrongChromaSize {
 		outputWriteBuffer = ""; // clear outputWriteBuffer
 
-		printAndAddToBuffer(analysisFactory.createPlugin(analysisKey).analyse(inputFile, force, verbose));
+		printAndAddToBuffer(analysisFactory.createAnalysis(analysisKey, verbose).analyse(inputFile, force));
 		return outputWriteBuffer;
 	}
 
 	public DataChart createDataChart(String inputFile, String analysisKey) throws LoadFailedException, OutputNotReady, ParseOutputError, IOException {
-		return dataChartFactory.createDataChart(analysisKey, analysisFactory.createPlugin(analysisKey).getDataFromOutput(inputFile));
+		return dataChartFactory.createDataChart(analysisKey, analysisFactory.createAnalysis(analysisKey).getDataFromOutput(inputFile));
 	}
 
 	// Analyses folder with given Analysis, writes to System.out as well as writes to outputWriteBuffer

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalyser.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalyser.java
@@ -163,7 +163,7 @@ public class AudioAnalyser {
 					if (file.toString().endsWith(suffixAndExtension)) {
 						printAndAddToBuffer("\nProcessing: " + file.toString() + "\n");
 						try {
-							printAndAddToBuffer(runAnalysis(file.toString(), analysisKey, false, false));
+							runAnalysis(file.toString(), analysisKey, false, false);
 						} catch (AudioAnalyser.IncorrectInputException | AudioAnalyser.LoadFailedException e) {
 							printAndAddToBuffer("\nERROR: " + e.getMessage());
 						} catch (AudioAnalyser.OutputAlreadyExists e) {

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalysisHelper.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalysisHelper.java
@@ -91,11 +91,11 @@ public class AudioAnalysisHelper {
 	public static float getFloatFromLine(String line) { return Float.parseFloat(line.substring(line.lastIndexOf(':') + 2)); }
 
 	// gets ArrayList of Float from the line, after ':'
-	public static ArrayList<Float> getFloatArrayFromLine(String line, int size) throws AudioAnalyser.IncorrectInputException {
+	public static ArrayList<Float> getFloatArrayFromLine(String line) throws AudioAnalyser.IncorrectInputException {
 		ArrayList<Float> result = new ArrayList<>();
 		String floatValues = line.substring(line.lastIndexOf(':') + 2);
 		Scanner sc = new Scanner(floatValues);
-		for (int i = 0; i < size; i++) {
+		while (sc.hasNextFloat()) {
 			if (sc.hasNextFloat()) {
 				result.add(sc.nextFloat());
 			} else {

--- a/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalysisHelper.java
+++ b/src/main/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalysisHelper.java
@@ -2,8 +2,7 @@ package org.harmony_analyser.jharmonyanalyser.services;
 
 import org.harmony_analyser.jharmonyanalyser.chord_analyser.*;
 
-import java.util.Arrays;
-import java.util.Scanner;
+import java.util.*;
 
 /**
  * Class to contain all relevant helper functions for audio analysis
@@ -91,14 +90,14 @@ public class AudioAnalysisHelper {
 	// gets float from the line, after ':'
 	public static float getFloatFromLine(String line) { return Float.parseFloat(line.substring(line.lastIndexOf(':') + 2)); }
 
-	// gets float array (with given size) from the line, after ':'
-	public static float[] getFloatArrayFromLine(String line, int size) throws AudioAnalyser.IncorrectInputException {
-		float[] result = new float[size];
+	// gets ArrayList of Float from the line, after ':'
+	public static ArrayList<Float> getFloatArrayFromLine(String line, int size) throws AudioAnalyser.IncorrectInputException {
+		ArrayList<Float> result = new ArrayList<>();
 		String floatValues = line.substring(line.lastIndexOf(':') + 2);
 		Scanner sc = new Scanner(floatValues);
 		for (int i = 0; i < size; i++) {
 			if (sc.hasNextFloat()) {
-				result[i] = sc.nextFloat();
+				result.add(sc.nextFloat());
 			} else {
 				throw new AudioAnalyser.IncorrectInputException("Float array information is invalid.");
 			}

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/AnalysisFactoryTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/AnalysisFactoryTest.java
@@ -32,7 +32,7 @@ public class AnalysisFactoryTest {
 		AverageChordComplexityDistancePlugin transitionComplexityPlugin = mock(AverageChordComplexityDistancePlugin.class);
 		whenNew(AverageChordComplexityDistancePlugin.class).withNoArguments().thenReturn(transitionComplexityPlugin);
 
-		Analysis analysisPlugin = analysisFactory.createPlugin("chord_analyser:average_chord_complexity_distance");
+		Analysis analysisPlugin = analysisFactory.createAnalysis("chord_analyser:average_chord_complexity_distance");
 
 		verifyNew(AverageChordComplexityDistancePlugin.class).withNoArguments();
 	}

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/AnalysisPluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/AnalysisPluginTest.java
@@ -21,6 +21,6 @@ public class AnalysisPluginTest {
 
 	@Test(expected = AudioAnalyser.IncorrectInputException.class)
 	public void shouldThrowForIncorrectInputFiles() throws AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists {
-		chordino.checkInputFiles(inputFile, true);
+		chordino.checkInputFiles(inputFile);
 	}
 }

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordComplexityDistancePluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordComplexityDistancePluginTest.java
@@ -36,8 +36,9 @@ public class ChordComplexityDistancePluginTest {
 	public void shouldCreateReport() throws IOException, AudioAnalyser.IncorrectInputException, PluginLoader.LoadFailedException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		new NNLSPlugin().analyse(testWavFile.toString(), true);
 		new ChordinoLabelsPlugin().analyse(testWavFile.toString(), true);
-		new ChordComplexityDistancePlugin().analyse(testWavFile.toString(), true);
-		BufferedReader readerReport = new BufferedReader(new FileReader(testWavFile.toString() + "-cc-distance.txt"));
+		ChordComplexityDistancePlugin ccd = new ChordComplexityDistancePlugin();
+		ccd.analyse(testWavFile.toString(), true);
+		BufferedReader readerReport = new BufferedReader(new FileReader(ccd.outputFile));
 		BufferedReader readerFixture = new BufferedReader(new FileReader(testReportFixture));
 		StringBuilder reportString = new StringBuilder();
 		StringBuilder fixtureString = new StringBuilder();

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordComplexityDistancePluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/ChordComplexityDistancePluginTest.java
@@ -34,9 +34,9 @@ public class ChordComplexityDistancePluginTest {
 
 	@Test
 	public void shouldCreateReport() throws IOException, AudioAnalyser.IncorrectInputException, PluginLoader.LoadFailedException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		new NNLSPlugin().analyse(testWavFile.toString(), true, false);
-		new ChordinoLabelsPlugin().analyse(testWavFile.toString(), true, false);
-		new ChordComplexityDistancePlugin().analyse(testWavFile.toString(), true, false);
+		new NNLSPlugin().analyse(testWavFile.toString(), true);
+		new ChordinoLabelsPlugin().analyse(testWavFile.toString(), true);
+		new ChordComplexityDistancePlugin().analyse(testWavFile.toString(), true);
 		BufferedReader readerReport = new BufferedReader(new FileReader(testWavFile.toString() + "-cc-distance.txt"));
 		BufferedReader readerFixture = new BufferedReader(new FileReader(testReportFixture));
 		StringBuilder reportString = new StringBuilder();

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/HarmonicComplexityPluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/HarmonicComplexityPluginTest.java
@@ -32,8 +32,9 @@ public class HarmonicComplexityPluginTest {
 	public void shouldCreateReport() throws IOException, AudioAnalyser.IncorrectInputException, PluginLoader.LoadFailedException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		new NNLSPlugin().analyse(testWavFile.toString(), true);
 		new ChordinoLabelsPlugin().analyse(testWavFile.toString(), true);
-		new AverageChordComplexityDistancePlugin().analyse(testWavFile.toString(), true);
-		BufferedReader readerReport = new BufferedReader(new FileReader(testWavFile.toString() + "-average-cc-distance.txt"));
+		AverageChordComplexityDistancePlugin accd = new AverageChordComplexityDistancePlugin();
+		accd.analyse(testWavFile.toString(), true);
+		BufferedReader readerReport = new BufferedReader(new FileReader(accd.outputFile));
 		BufferedReader readerFixture = new BufferedReader(new FileReader(testReportFixture));
 		StringBuilder reportString = new StringBuilder();
 		StringBuilder fixtureString = new StringBuilder();

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/HarmonicComplexityPluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/chordanal_plugins/HarmonicComplexityPluginTest.java
@@ -30,9 +30,9 @@ public class HarmonicComplexityPluginTest {
 
 	@Test
 	public void shouldCreateReport() throws IOException, AudioAnalyser.IncorrectInputException, PluginLoader.LoadFailedException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		new NNLSPlugin().analyse(testWavFile.toString(), true, false);
-		new ChordinoLabelsPlugin().analyse(testWavFile.toString(), true, false);
-		new AverageChordComplexityDistancePlugin().analyse(testWavFile.toString(), true, false);
+		new NNLSPlugin().analyse(testWavFile.toString(), true);
+		new ChordinoLabelsPlugin().analyse(testWavFile.toString(), true);
+		new AverageChordComplexityDistancePlugin().analyse(testWavFile.toString(), true);
 		BufferedReader readerReport = new BufferedReader(new FileReader(testWavFile.toString() + "-average-cc-distance.txt"));
 		BufferedReader readerFixture = new BufferedReader(new FileReader(testReportFixture));
 		StringBuilder reportString = new StringBuilder();

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoPluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoPluginTest.java
@@ -29,7 +29,7 @@ public class ChordinoPluginTest {
 	@Test
 	public void shouldExtractChords() throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		chordino.analyse(testWavFile.toString(), true);
-		BufferedReader reader = new BufferedReader(new FileReader(testWavFile.toString() + "-chordino-labels.txt"));
+		BufferedReader reader = new BufferedReader(new FileReader(chordino.outputFile));
 		String line = reader.readLine();
 		assertEquals(" 0.371519274: N", line);
 		line = reader.readLine();

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoPluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/ChordinoPluginTest.java
@@ -28,7 +28,7 @@ public class ChordinoPluginTest {
 
 	@Test
 	public void shouldExtractChords() throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		chordino.analyse(testWavFile.toString(), true, false);
+		chordino.analyse(testWavFile.toString(), true);
 		BufferedReader reader = new BufferedReader(new FileReader(testWavFile.toString() + "-chordino-labels.txt"));
 		String line = reader.readLine();
 		assertEquals(" 0.371519274: N", line);

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/NNLSPluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/NNLSPluginTest.java
@@ -30,7 +30,7 @@ public class NNLSPluginTest {
 	@Test
 	public void shouldExtractChromas() throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		nnls.analyse(testWavFile.toString(), true);
-		BufferedReader reader = new BufferedReader(new FileReader(testWavFile.toString() + "-chromas.txt"));
+		BufferedReader reader = new BufferedReader(new FileReader(nnls.outputFile));
 		String line = reader.readLine();
 		float timestamp = AudioAnalysisHelper.getTimestampFromLine(line);
 		String chromaString = AudioAnalysisHelper.getLabelFromLine(line);

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/NNLSPluginTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/plugins/vamp_plugins/NNLSPluginTest.java
@@ -29,7 +29,7 @@ public class NNLSPluginTest {
 
 	@Test
 	public void shouldExtractChromas() throws IOException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
-		nnls.analyse(testWavFile.toString(), true, false);
+		nnls.analyse(testWavFile.toString(), true);
 		BufferedReader reader = new BufferedReader(new FileReader(testWavFile.toString() + "-chromas.txt"));
 		String line = reader.readLine();
 		float timestamp = AudioAnalysisHelper.getTimestampFromLine(line);

--- a/src/test/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalyserTest.java
+++ b/src/test/java/org/harmony_analyser/jharmonyanalyser/services/AudioAnalyserTest.java
@@ -66,10 +66,10 @@ public class AudioAnalyserTest {
 	@Test
 	public void shouldCallPluginAnalyse() throws IOException, AudioAnalyser.LoadFailedException, AudioAnalyser.IncorrectInputException, AudioAnalyser.OutputAlreadyExists, Chroma.WrongChromaSize {
 		AnalysisPlugin analysisPlugin = mock(AnalysisPlugin.class);
-		when(analysisPlugin.analyse(testWavFile.toString(), true, false)).thenReturn("Done!");
+		when(analysisPlugin.analyse(testWavFile.toString(), true)).thenReturn("Done!");
 
 		AnalysisFactory analysisFactory = new AnalysisFactory() {
-			public AnalysisPlugin createPlugin(String analysisKey) {
+			public AnalysisPlugin createAnalysis(String analysisKey) {
 				return analysisPlugin;
 			}
 		};


### PR DESCRIPTION
- removes `verbose` parameters and text outputs, it is now written to `System.out`
- all 'flat time series' (e.g. chord vectors in the form of time series with fixed sample rate) now have `-flat.txt` suffix
- `.wav` is omitted from output file names. For `song.wav` the analysis files are now in the form `song-analysis.txt`

plus: fix for flat time series - it will now work for both scalars and vectors of arbitrary size